### PR TITLE
fix(chrono): Remove dependency to the time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13"
-chrono = { version = "0.4", features = ["serde"] }
+# Switching off default features removes a dependency to the "time" crate that
+# contains a potential security issue.
+# See https://github.com/time-rs/time/issues/293
+chrono = { version = "0.4", features = ["clock", "serde"], default-features = false }
 futures = "0.3"
 derive_more = "0.99"
 hmac = "0.11"


### PR DESCRIPTION
Problem: Github Dependabot reports a security issue in the time crate from https://github.com/chronotope/chrono/issues/602

The time crate is an optional dependency of chrono, so we can disable it.